### PR TITLE
Fix VP seating mapping to remain constant

### DIFF
--- a/tabletop_ux_kivy.py
+++ b/tabletop_ux_kivy.py
@@ -212,8 +212,10 @@ class TabletopRoot(FloatLayout):
         self.signaler = 1
         self.judge = 2
         self.phase = PH_WAIT_BOTH_START
-        self.role_by_physical = {1: 1, 2: 2}
-        self.physical_by_role = {1: 1, 2: 2}
+        # Versuchsperson 1 sitzt immer unten (Spieler 1), Versuchsperson 2 oben (Spieler 2)
+        self._fixed_role_mapping = {1: 1, 2: 2}
+        self.role_by_physical = self._fixed_role_mapping.copy()
+        self.physical_by_role = {role: player for player, role in self.role_by_physical.items()}
         self.session_number = None
         self.session_id = None
         self.logger = None
@@ -1308,10 +1310,10 @@ class TabletopRoot(FloatLayout):
         return (None, None)
 
     def update_role_assignments(self):
-        if self.signaler == 1:
-            self.role_by_physical = {1: 1, 2: 2}
-        else:
-            self.role_by_physical = {1: 2, 2: 1}
+        """Stelle sicher, dass die Versuchspersonen fest ihren Sitzplätzen zugeordnet bleiben."""
+        # Die Sitzordnung ist fix: Spieler 1 unten = VP1, Spieler 2 oben = VP2.
+        # Rollenwechsel (Signaler/Judge) wird separat über self.signaler/self.judge abgebildet.
+        self.role_by_physical = self._fixed_role_mapping.copy()
         self.physical_by_role = {role: player for player, role in self.role_by_physical.items()}
 
     def current_engine_phase(self):


### PR DESCRIPTION
## Summary
- ensure Versuchsperson 1/2 remain tied to the bottom/top players regardless of role swaps
- update role assignment helper to respect the fixed seating and keep inverse mapping in sync

## Testing
- not run (Kivy application requires GUI environment)


------
https://chatgpt.com/codex/tasks/task_e_68e44b8af6e883278943d0852ed2bb3a